### PR TITLE
Add scaffold for zoomable sticky notes app

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+backend/data/app.db

--- a/backend/api.php
+++ b/backend/api.php
@@ -1,0 +1,87 @@
+<?php
+header('Content-Type: application/json');
+$db = new PDO('sqlite:' . __DIR__ . '/data/app.db');
+$db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+
+$method = $_SERVER['REQUEST_METHOD'];
+$action = $_GET['action'] ?? '';
+
+switch ($action) {
+  case 'register':
+    if ($method !== 'POST') { http_response_code(405); exit; }
+    $data = json_decode(file_get_contents('php://input'), true);
+    $stmt = $db->prepare('INSERT INTO users (username, password) VALUES (?, ?)');
+    $stmt->execute([$data['username'], password_hash($data['password'], PASSWORD_DEFAULT)]);
+    echo json_encode(['status' => 'ok']);
+    break;
+  case 'login':
+    if ($method !== 'POST') { http_response_code(405); exit; }
+    $data = json_decode(file_get_contents('php://input'), true);
+    $stmt = $db->prepare('SELECT * FROM users WHERE username = ?');
+    $stmt->execute([$data['username']]);
+    $user = $stmt->fetch(PDO::FETCH_ASSOC);
+    if ($user && password_verify($data['password'], $user['password'])) {
+      echo json_encode(['status' => 'ok', 'user_id' => $user['id']]);
+    } else {
+      http_response_code(401);
+      echo json_encode(['error' => 'Invalid credentials']);
+    }
+    break;
+  case 'notes':
+    if ($method === 'GET') {
+      $user_id = $_GET['user_id'] ?? null;
+      $stmt = $db->prepare('SELECT * FROM notes WHERE user_id = ?');
+      $stmt->execute([$user_id]);
+      echo json_encode($stmt->fetchAll(PDO::FETCH_ASSOC));
+    } elseif ($method === 'POST') {
+      $data = json_decode(file_get_contents('php://input'), true);
+      $stmt = $db->prepare('INSERT INTO notes (user_id, title, content, x, y, color, location, cost, timeline_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)');
+      $stmt->execute([
+        $data['user_id'],
+        $data['title'],
+        $data['content'],
+        $data['x'],
+        $data['y'],
+        $data['color'],
+        $data['location'],
+        $data['cost'],
+        $data['timeline_at']
+      ]);
+      echo json_encode(['status' => 'ok', 'id' => $db->lastInsertId()]);
+    } elseif ($method === 'PUT') {
+      parse_str($_SERVER['QUERY_STRING'], $query);
+      $id = $query['id'] ?? null;
+      $data = json_decode(file_get_contents('php://input'), true);
+      $stmt = $db->prepare('UPDATE notes SET title = ?, content = ?, x = ?, y = ?, color = ?, location = ?, cost = ?, timeline_at = ? WHERE id = ?');
+      $stmt->execute([
+        $data['title'],
+        $data['content'],
+        $data['x'],
+        $data['y'],
+        $data['color'],
+        $data['location'],
+        $data['cost'],
+        $data['timeline_at'],
+        $id
+      ]);
+      echo json_encode(['status' => 'ok']);
+    } elseif ($method === 'DELETE') {
+      $id = $_GET['id'] ?? null;
+      $stmt = $db->prepare('DELETE FROM notes WHERE id = ?');
+      $stmt->execute([$id]);
+      echo json_encode(['status' => 'ok']);
+    } else {
+      http_response_code(405);
+    }
+    break;
+  case 'costs':
+    if ($method !== 'GET') { http_response_code(405); exit; }
+    $user_id = $_GET['user_id'] ?? null;
+    $stmt = $db->prepare('SELECT SUM(cost) as total_cost FROM notes WHERE user_id = ?');
+    $stmt->execute([$user_id]);
+    $row = $stmt->fetch(PDO::FETCH_ASSOC);
+    echo json_encode(['total_cost' => $row['total_cost'] ?? 0]);
+    break;
+  default:
+    echo json_encode(['error' => 'Unknown action']);
+}

--- a/backend/init_db.php
+++ b/backend/init_db.php
@@ -1,0 +1,35 @@
+<?php
+$db = new PDO('sqlite:' . __DIR__ . '/data/app.db');
+$db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+
+$db->exec('CREATE TABLE IF NOT EXISTS users (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  username TEXT UNIQUE,
+  password TEXT,
+  created_at TEXT DEFAULT CURRENT_TIMESTAMP
+)');
+
+$db->exec('CREATE TABLE IF NOT EXISTS notes (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  user_id INTEGER,
+  title TEXT,
+  content TEXT,
+  x REAL,
+  y REAL,
+  color TEXT,
+  location TEXT,
+  cost REAL,
+  timeline_at TEXT,
+  created_at TEXT DEFAULT CURRENT_TIMESTAMP,
+  FOREIGN KEY(user_id) REFERENCES users(id)
+)');
+
+$db->exec('CREATE TABLE IF NOT EXISTS connections (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  note_a_id INTEGER,
+  note_b_id INTEGER,
+  FOREIGN KEY(note_a_id) REFERENCES notes(id),
+  FOREIGN KEY(note_b_id) REFERENCES notes(id)
+)');
+
+echo "Database initialized\n";

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -1,0 +1,26 @@
+const { useState, useCallback } = React;
+const { ReactFlow: ReactFlowComponent, addEdge, MiniMap, Controls, Background, applyNodeChanges, applyEdgeChanges } = window.ReactFlow;
+
+const initialNodes = [
+  { id: '1', position: { x: 0, y: 0 }, data: { label: 'First note' } }
+];
+const initialEdges = [];
+
+function App() {
+  const [nodes, setNodes] = useState(initialNodes);
+  const [edges, setEdges] = useState(initialEdges);
+
+  const onConnect = useCallback((params) => setEdges((eds) => addEdge(params, eds)), []);
+  const onNodesChange = useCallback((changes) => setNodes((nds) => applyNodeChanges(changes, nds)), []);
+  const onEdgesChange = useCallback((changes) => setEdges((eds) => applyEdgeChanges(changes, eds)), []);
+
+  return React.createElement(
+    ReactFlowComponent,
+    { nodes, edges, onConnect, onNodesChange, onEdgesChange, fitView: true },
+    React.createElement(MiniMap, null),
+    React.createElement(Controls, null),
+    React.createElement(Background, { gap: 16 })
+  );
+}
+
+ReactDOM.render(React.createElement(App), document.getElementById('root'));

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <title>Sticky Notes App</title>
+  <style>
+    #root { width: 100vw; height: 100vh; }
+  </style>
+  <link rel="stylesheet" href="https://unpkg.com/reactflow@11.10.0/dist/style.css" />
+  <script src="https://unpkg.com/react@18/umd/react.development.js"></script>
+  <script src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>
+  <script src="https://unpkg.com/reactflow@11.10.0/dist/reactflow.min.js"></script>
+</head>
+<body>
+  <div id="root"></div>
+  <script src="app.js"></script>
+</body>
+</html>

--- a/readme.md
+++ b/readme.md
@@ -1,0 +1,32 @@
+# Sticky Notes Scaffold
+
+This repository contains a minimal scaffold for a zoomable, connectable sticky notes application.
+
+## Backend (PHP + SQLite)
+
+1. Initialize the database:
+   ```bash
+   php backend/init_db.php
+   ```
+
+2. Start a simple development server:
+   ```bash
+   php -S localhost:8000 -t backend
+   ```
+
+API endpoints:
+- `POST /api.php?action=register` – body: `{ "username": "name", "password": "pass" }`
+- `POST /api.php?action=login`
+- `GET /api.php?action=notes&user_id=1`
+- `POST /api.php?action=notes`
+- `PUT /api.php?action=notes&id=1`
+- `DELETE /api.php?action=notes&id=1`
+- `GET /api.php?action=costs&user_id=1`
+
+## Frontend (React + React Flow)
+
+Open `frontend/index.html` in a browser. It uses React Flow to allow dragging notes, connecting them with lines, and zooming.
+
+## Notes
+
+This is a starting point and omits authentication sessions, Google Maps integration, and timeline view. These can be added incrementally.


### PR DESCRIPTION
## Summary
- scaffold PHP API with SQLite storage for users, notes, and costs
- add React Flow frontend demo for drag, zoom, and connections
- document usage and ignore local database

## Testing
- `php -l backend/init_db.php`
- `php -l backend/api.php`
- `node --check frontend/app.js`


------
https://chatgpt.com/codex/tasks/task_e_68b83a637710832f96cc988780032c35